### PR TITLE
Properly implement feed & extended feed

### DIFF
--- a/src/components/Feed/Feed.js
+++ b/src/components/Feed/Feed.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import "./Feed.css";
 
-function Feed() {
+function Feed(extendedFeed) {
   const [tweets, setTweets] = useState([]);
   const [loading, setLoading] = useState(true);
 

--- a/src/components/Feed/Feed.js
+++ b/src/components/Feed/Feed.js
@@ -6,11 +6,17 @@ function Feed() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("https://pstwitter.deno.dev/mock/tweets")
+    fetch("https://api.chirp.koenidv.de/v1/tweet", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + localStorage.getItem("jwt"),
+      },
+    })
       .then((response) => response.json())
       .then((data) => {
         console.log(data); // Log data to the console
-        setTweets(data?.tweets || []);
+        setTweets(data || []);
         setLoading(false);
       })
       .catch((error) => console.error(error));
@@ -32,13 +38,16 @@ function Feed() {
                     className="media"
                   />
                 )}
-                <p className="text">{tweet.text}</p>
+                <p className="text">{tweet.content}</p>
                 <p className="metadata">
                   Posted by: {tweet.author_id} on{" "}
-                  {new Date(tweet.timestamp).toLocaleString()}
+                  {new Date(tweet.created_at).toLocaleString()}
                 </p>
                 <div className="actions">
-                  <span className="likes">{tweet.likes} likes</span>
+                  <span className="likes">{tweet.like_count} likes</span>
+                  <span className="comments">
+                    {tweet.comment_count} comments
+                  </span>
                   {tweet.mentions?.length > 0 && (
                     <ul className="mentions">
                       {tweet.mentions.map((mention) => (

--- a/src/components/Feed/Feed.js
+++ b/src/components/Feed/Feed.js
@@ -6,13 +6,16 @@ function Feed(extendedFeed) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("https://api.chirp.koenidv.de/v1/tweet", {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer " + localStorage.getItem("jwt"),
-      },
-    })
+    fetch(
+      `https://api.chirp.koenidv.de/v1/tweet${extendedFeed ? "/extend" : ""}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer " + localStorage.getItem("jwt"),
+        },
+      }
+    )
       .then((response) => response.json())
       .then((data) => {
         console.log(data); // Log data to the console
@@ -20,7 +23,7 @@ function Feed(extendedFeed) {
         setLoading(false);
       })
       .catch((error) => console.error(error));
-  }, []);
+  }, [extendedFeed]);
 
   return (
     <div className="feed">

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -29,15 +29,18 @@ nav li:last-child {
   margin-right: 0;
 }
 
-nav a {
+nav button {
   display: block;
+  font-size: 1rem;
   padding: 8px 10px;
   text-decoration: none;
   color: #eaeef1;
   border-radius: 30px;
+  border: unset;
+  background-color: unset;
   transition: background-color 0.2s;
 }
 
-nav a:hover {
+nav button:hover {
   background-color: #3e4a53;
 }

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,7 +1,7 @@
 import React from "react";
 import "./Header.css";
 
-const Header = ({ title, isProfilePage }) => {
+const Header = ({ title, isProfilePage, extendedFeedCb }) => {
   return (
     <header>
       <div className="container">
@@ -15,10 +15,10 @@ const Header = ({ title, isProfilePage }) => {
               <nav>
                 <ul>
                   <li>
-                    <a href="./index.js">Following</a>
+                    <button onClick={() => extendedFeedCb(false)}>Following</button>
                   </li>
                   <li>
-                    <a href="./index.js">Friends are Following</a>
+                    <button onClick={() => extendedFeedCb(true)}>Friends are Following</button>
                   </li>
                 </ul>
               </nav>

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -4,14 +4,20 @@ import Header from "../../components/Header/Header";
 import Sidebar from "../../components/Sidebar/Sidebar";
 import Footer from "../../components/Footer/Footer";
 import Feed from "../../components/Feed/Feed";
+import { useState } from "react";
 
 function Home() {
+  let [extendedFeed, setExtendedFeed] = useState(false);
+
   return (
     <div className="Home">
-      <Header isProfilePage={false} />
+      <Header
+        isProfilePage={false}
+        extendedFeedCb={(it) => setExtendedFeed(it)}
+      />
       <div className="content">
         <Sidebar />
-        <Feed />
+        <Feed extendedFeed={extendedFeed} />
       </div>
       <Footer />
     </div>


### PR DESCRIPTION
This PR:
- Calls the live posts API instead of the mock endpoint
- Allows for fetching the extended feed
- Fixes the header navigation for feed and extended feed

The navigation implementation is horrible, the extended state should not be handled by the Home component. I still implemented it this way because it fits the current code style.